### PR TITLE
1.17+

### DIFF
--- a/health_editor/data/editor/functions/damage/dfin.mcfunction
+++ b/health_editor/data/editor/functions/damage/dfin.mcfunction
@@ -2,5 +2,5 @@ effect give @s minecraft:instant_health 1 200 true
 execute if score @s iswearinghelm matches 1 run function editor:damage/link
 execute if score @s iswearinghelm matches 1 run loot replace entity @s armor.head mine 1 0 0 stick{drop_contents:true}
 execute unless score @s iswearinghelm matches 1 run replaceitem entity @s armor.head air
-replaceitem block 1 0 0 container.0 dirt
+item replace block 1 0 0 container.0 with minecraft:dirt
 tag @s remove dfin


### PR DESCRIPTION
/replaceitem gets removed in 1.17. /item replace replaced the command.